### PR TITLE
Add migration to purge duplicate activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Current (in progress)
 
--  Do not crash if file doesn't exists during resource deletion [#3323](https://github.com/opendatateam/udata/pull/3323) 
+- Add activities to dataservices and resources, add Auditable class to refactor improve code [#3308](https://github.com/opendatateam/udata/pull/3308)
+- Do not crash if file doesn't exists during resource deletion [#3323](https://github.com/opendatateam/udata/pull/3323)
 - Show user domain in suggest [#3324](https://github.com/opendatateam/udata/pull/3324)
 
 ## 10.4.1 (2025-05-20)

--- a/udata/core/activity/__init__.py
+++ b/udata/core/activity/__init__.py
@@ -6,6 +6,7 @@ log = logging.getLogger(__name__)
 def init_app(app):
     # Load all core actvitiess
     import udata.core.user.activities  # noqa
+    import udata.core.dataservices.activities  # noqa
     import udata.core.dataset.activities  # noqa
     import udata.core.reuse.activities  # noqa
     import udata.core.organization.activities  # noqa

--- a/udata/core/activity/api.py
+++ b/udata/core/activity/api.py
@@ -46,6 +46,7 @@ activity_fields = api.model(
         "label": fields.String(description="The label of the activity", required=True),
         "key": fields.String(description="The key of the activity", required=True),
         "icon": fields.String(description="The icon of the activity", required=True),
+        "changes": fields.List(fields.String, description="Changed attributes as list"),
         "extras": fields.Raw(description="Extras attributes as key-value pairs"),
     },
 )

--- a/udata/core/activity/tasks.py
+++ b/udata/core/activity/tasks.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Iterable
 
 from udata.models import Organization, User, db
 from udata.tasks import task
@@ -9,28 +10,36 @@ log = logging.getLogger(__name__)
 
 
 @new_activity.connect
-def delay_activity(cls, related_to, actor, organization=None, extras=None):
+def delay_activity(cls, related_to, actor, organization=None, changes=None, extras=None):
     emit_activity.delay(
         cls.__name__,
         str(actor.id),
         related_to_cls=related_to.__class__.__name__,
         related_to_id=str(related_to.id),
         organization_id=str(organization.id) if organization else None,
+        changes=changes,
         extras=extras,
     )
 
 
 @task
 def emit_activity(
-    classname, actor_id, related_to_cls, related_to_id, organization_id=None, extras=None
+    classname,
+    actor_id,
+    related_to_cls,
+    related_to_id,
+    organization_id=None,
+    changes=None,
+    extras=None,
 ):
     log.debug(
-        "Emit new activity: %s %s %s %s %s %s",
+        "Emit new activity: %s %s %s %s %s %s %s",
         classname,
         actor_id,
         related_to_cls,
         related_to_id,
         organization_id,
+        ", ".join(changes) if changes and isinstance(changes, Iterable) else "",
         extras,
     )
     cls = db.resolve_model(classname)
@@ -40,4 +49,10 @@ def emit_activity(
         organization = Organization.objects.get(pk=organization_id)
     else:
         organization = None
-    cls.objects.create(actor=actor, related_to=related_to, organization=organization, extras=extras)
+    cls.objects.create(
+        actor=actor,
+        related_to=related_to,
+        organization=organization,
+        changes=changes,
+        extras=extras,
+    )

--- a/udata/core/dataservices/activities.py
+++ b/udata/core/dataservices/activities.py
@@ -1,0 +1,53 @@
+from udata.auth import current_user
+from udata.i18n import lazy_gettext as _
+from udata.models import Activity, Dataservice, db
+
+__all__ = (
+    "UserCreatedDataservice",
+    "UserUpdatedDataservice",
+    "UserDeletedDataservice",
+    "DataserviceRelatedActivity",
+)
+
+
+class DataserviceRelatedActivity(object):
+    related_to = db.ReferenceField("Dataservice")
+
+
+class UserCreatedDataservice(DataserviceRelatedActivity, Activity):
+    key = "dataservice:created"
+    icon = "fa fa-plus"
+    badge_type = "success"
+    label = _("created a dataservice")
+
+
+class UserUpdatedDataservice(DataserviceRelatedActivity, Activity):
+    key = "dataservice:updated"
+    icon = "fa fa-pencil"
+    label = _("updated a dataservice")
+
+
+class UserDeletedDataservice(DataserviceRelatedActivity, Activity):
+    key = "dataservice:deleted"
+    icon = "fa fa-remove"
+    badge_type = "error"
+    label = _("deleted a dataservice")
+
+
+@Dataservice.on_create.connect
+def on_user_created_dataservice(dataservice):
+    if not dataservice.private and current_user and current_user.is_authenticated:
+        UserCreatedDataservice.emit(dataservice, dataservice.organization)
+
+
+@Dataservice.on_update.connect
+def on_user_updated_dataservice(dataservice, **kwargs):
+    changed_fields = kwargs.get("changed_fields", [])
+    if not dataservice.private and current_user and current_user.is_authenticated:
+        UserUpdatedDataservice.emit(dataservice, dataservice.organization, changed_fields)
+
+
+@Dataservice.on_delete.connect
+def on_user_deleted_dataservice(dataservice):
+    if not dataservice.private and current_user and current_user.is_authenticated:
+        UserDeletedDataservice.emit(dataservice, dataservice.organization)

--- a/udata/core/dataservices/models.py
+++ b/udata/core/dataservices/models.py
@@ -8,6 +8,7 @@ from mongoengine.signals import post_save
 import udata.core.contact_point.api_fields as contact_api_fields
 import udata.core.dataset.api_fields as datasets_api_fields
 from udata.api_fields import field, function_field, generate_fields
+from udata.core.activity.models import Auditable
 from udata.core.dataservices.constants import DATASERVICE_ACCESS_TYPES, DATASERVICE_FORMATS
 from udata.core.dataset.models import Dataset
 from udata.core.metrics.models import WithMetrics
@@ -105,7 +106,7 @@ class HarvestMetadata(db.EmbeddedDocument):
         {"key": "views", "value": "metrics.views"},
     ],
 )
-class Dataservice(WithMetrics, Owned, db.Document):
+class Dataservice(Auditable, WithMetrics, Owned, db.Document):
     meta = {
         "indexes": [
             "$title",
@@ -116,6 +117,11 @@ class Dataservice(WithMetrics, Owned, db.Document):
         "queryset_class": DataserviceQuerySet,
         "auto_create_index_on_save": True,
     }
+
+    after_save = Signal()
+    on_create = Signal()
+    on_update = Signal()
+    on_delete = Signal()
 
     verbose_name = _("dataservice")
 
@@ -175,7 +181,10 @@ class Dataservice(WithMetrics, Owned, db.Document):
         description="Is the dataservice private to the owner or the organization",
     )
 
-    extras = field(db.ExtrasField())
+    extras = field(
+        db.ExtrasField(),
+        auditable=False,
+    )
 
     contact_points = field(
         db.ListField(
@@ -201,8 +210,9 @@ class Dataservice(WithMetrics, Owned, db.Document):
         ),
         readonly=True,
         sortable="last_modified",
+        auditable=False,
     )
-    deleted_at = field(db.DateTimeField())
+    deleted_at = field(db.DateTimeField(), auditable=False)
     archived_at = field(db.DateTimeField())
 
     datasets = field(
@@ -223,6 +233,7 @@ class Dataservice(WithMetrics, Owned, db.Document):
     harvest = field(
         db.EmbeddedDocumentField(HarvestMetadata),
         readonly=True,
+        auditable=False,
     )
 
     def url_for(self, *args, **kwargs):
@@ -250,26 +261,11 @@ class Dataservice(WithMetrics, Owned, db.Document):
 
     def count_discussions(self):
         self.metrics["discussions"] = Discussion.objects(subject=self, closed=None).count()
-        self.save()
+        self.save(signal_kwargs={"ignores": ["post_save"]})
 
     def count_followers(self):
         self.metrics["followers"] = Follow.objects(until=None).followers(self).count()
-        self.save()
-
-    on_create = Signal()
-    on_update = Signal()
-    on_delete = Signal()
-
-    @classmethod
-    def post_save(cls, sender, document, **kwargs):
-        if "post_save" in kwargs.get("ignores", []):
-            return
-        if kwargs.get("created"):
-            cls.on_create.send(document)
-        else:
-            cls.on_update.send(document)
-        if document.deleted_at:
-            cls.on_delete.send(document)
+        self.save(signal_kwargs={"ignores": ["post_save"]})
 
 
 post_save.connect(Dataservice.post_save, sender=Dataservice)

--- a/udata/core/dataset/activities.py
+++ b/udata/core/dataset/activities.py
@@ -35,6 +35,52 @@ class UserDeletedDataset(DatasetRelatedActivity, Activity):
     label = _("deleted a dataset")
 
 
+class UserAddedResourceToDataset(DatasetRelatedActivity, Activity):
+    key = "dataset:resource:added"
+    icon = "fa fa-plus"
+    label = _("added a resource to a dataset")
+
+
+class UserUpdatedResource(DatasetRelatedActivity, Activity):
+    key = "dataset:resource:updated"
+    icon = "fa fa-pencil"
+    label = _("updated a resource")
+
+
+class UserRemovedResourceFromDataset(DatasetRelatedActivity, Activity):
+    key = "dataset:resource:deleted"
+    icon = "fa fa-remove"
+    label = _("removed a resource from a dataset")
+
+
+@Dataset.on_resource_added.connect
+def on_user_added_resource_to_dataset(sender, document, **kwargs):
+    if not document.private and current_user and current_user.is_authenticated:
+        UserAddedResourceToDataset.emit(
+            document, document.organization, None, {"resource_id": str(kwargs["resource_id"])}
+        )
+
+
+@Dataset.on_resource_updated.connect
+def on_user_updated_resource(sender, document, **kwargs):
+    changed_fields = kwargs.get("changed_fields", [])
+    if not document.private and current_user and current_user.is_authenticated:
+        UserUpdatedResource.emit(
+            document,
+            document.organization,
+            changed_fields,
+            {"resource_id": str(kwargs["resource_id"])},
+        )
+
+
+@Dataset.on_resource_removed.connect
+def on_user_removed_resource_from_dataset(sender, document, **kwargs):
+    if not document.private and current_user and current_user.is_authenticated:
+        UserRemovedResourceFromDataset.emit(
+            document, document.organization, None, {"resource_id": str(kwargs["resource_id"])}
+        )
+
+
 @Dataset.on_create.connect
 def on_user_created_dataset(dataset):
     if not dataset.private and current_user and current_user.is_authenticated:
@@ -42,9 +88,10 @@ def on_user_created_dataset(dataset):
 
 
 @Dataset.on_update.connect
-def on_user_updated_dataset(dataset):
+def on_user_updated_dataset(dataset, **kwargs):
+    changed_fields = kwargs.get("changed_fields", [])
     if not dataset.private and current_user and current_user.is_authenticated:
-        UserUpdatedDataset.emit(dataset, dataset.organization)
+        UserUpdatedDataset.emit(dataset, dataset.organization, changed_fields)
 
 
 @Dataset.on_delete.connect

--- a/udata/core/metrics/models.py
+++ b/udata/core/metrics/models.py
@@ -8,6 +8,7 @@ class WithMetrics(object):
     metrics = field(
         db.DictField(),
         readonly=True,
+        auditable=False,
     )
 
     __metrics_keys__ = []

--- a/udata/core/organization/activities.py
+++ b/udata/core/organization/activities.py
@@ -32,6 +32,7 @@ def on_user_created_organization(organization):
 
 
 @Organization.on_update.connect
-def on_user_updated_organization(organization):
+def on_user_updated_organization(organization, **kwargs):
+    changed_fields = kwargs.get("changed_fields", [])
     if current_user and current_user.is_authenticated:
-        UserUpdatedOrganization.emit(organization, organization)
+        UserUpdatedOrganization.emit(organization, organization, changed_fields)

--- a/udata/core/owned.py
+++ b/udata/core/owned.py
@@ -80,7 +80,7 @@ def check_organization_is_valid_for_current_user(organization, **_kwargs):
 
 class Owned(object):
     """
-    A mixin to factorize owning behvaior between users and organizations.
+    A mixin to factorize owning behavior between users and organizations.
     """
 
     owner = field(

--- a/udata/core/reuse/activities.py
+++ b/udata/core/reuse/activities.py
@@ -38,9 +38,10 @@ def on_user_created_reuse(reuse):
 
 
 @Reuse.on_update.connect
-def on_user_updated_reuse(reuse):
+def on_user_updated_reuse(reuse, **kwargs):
+    changed_fields = kwargs.get("changed_fields", [])
     if not reuse.private and current_user and current_user.is_authenticated:
-        UserUpdatedReuse.emit(reuse, reuse.organization)
+        UserUpdatedReuse.emit(reuse, reuse.organization, changed_fields)
 
 
 @Reuse.on_delete.connect

--- a/udata/core/reuse/models.py
+++ b/udata/core/reuse/models.py
@@ -3,6 +3,7 @@ from mongoengine.signals import post_save, pre_save
 from werkzeug.utils import cached_property
 
 from udata.api_fields import field, function_field, generate_fields
+from udata.core.activity.models import Auditable
 from udata.core.dataset.api_fields import dataset_fields
 from udata.core.owned import Owned, OwnedQuerySet
 from udata.core.reuse.api_fields import BIGGEST_IMAGE_SIZE
@@ -60,7 +61,7 @@ class ReuseBadgeMixin(BadgeMixin):
     additional_filters={"organization_badge": "organization.badges"},
     mask="*,datasets{id,title,uri,page}",
 )
-class Reuse(db.Datetimed, WithMetrics, ReuseBadgeMixin, Owned, db.Document):
+class Reuse(db.Datetimed, Auditable, WithMetrics, ReuseBadgeMixin, Owned, db.Document):
     title = field(
         db.StringField(required=True),
         sortable=True,
@@ -71,6 +72,7 @@ class Reuse(db.Datetimed, WithMetrics, ReuseBadgeMixin, Owned, db.Document):
             max_length=255, required=True, populate_from="title", update=True, follow=True
         ),
         readonly=True,
+        auditable=False,
     )
     description = field(
         db.StringField(required=True),
@@ -126,15 +128,17 @@ class Reuse(db.Datetimed, WithMetrics, ReuseBadgeMixin, Owned, db.Document):
     private = field(db.BooleanField(default=False), filterable={})
 
     ext = db.MapField(db.GenericEmbeddedDocumentField())
-    extras = field(db.ExtrasField())
+    extras = field(db.ExtrasField(), auditable=False)
 
     featured = field(
         db.BooleanField(),
         filterable={},
         readonly=True,
+        auditable=False,
     )
     deleted = field(
         db.DateTimeField(),
+        auditable=False,
     )
     archived = field(
         db.DateTimeField(),
@@ -180,18 +184,6 @@ class Reuse(db.Datetimed, WithMetrics, ReuseBadgeMixin, Owned, db.Document):
     def pre_save(cls, sender, document, **kwargs):
         # Emit before_save
         cls.before_save.send(document)
-
-    @classmethod
-    def post_save(cls, sender, document, **kwargs):
-        if "post_save" in kwargs.get("ignores", []):
-            return
-        cls.after_save.send(document)
-        if kwargs.get("created"):
-            cls.on_create.send(document)
-        else:
-            cls.on_update.send(document)
-        if document.deleted:
-            cls.on_delete.send(document)
 
     def url_for(self, *args, **kwargs):
         return endpoint_for("reuses.show", "api.reuse", reuse=self, *args, **kwargs)
@@ -289,13 +281,13 @@ class Reuse(db.Datetimed, WithMetrics, ReuseBadgeMixin, Owned, db.Document):
         from udata.models import Discussion
 
         self.metrics["discussions"] = Discussion.objects(subject=self, closed=None).count()
-        self.save()
+        self.save(signal_kwargs={"ignores": ["post_save"]})
 
     def count_followers(self):
         from udata.models import Follow
 
         self.metrics["followers"] = Follow.objects(until=None).followers(self).count()
-        self.save()
+        self.save(signal_kwargs={"ignores": ["post_save"]})
 
 
 pre_save.connect(Reuse.pre_save, sender=Reuse)

--- a/udata/core/user/activities.py
+++ b/udata/core/user/activities.py
@@ -30,11 +30,6 @@ class DiscussActivity(object):
     badge_type = "warning"
 
 
-class UserStarredOrganization(FollowActivity, OrgRelatedActivity, Activity):
-    key = "organization:followed"
-    label = _("followed an organization")
-
-
 class UserFollowedUser(FollowActivity, Activity):
     key = "user:followed"
     label = _("followed a user")

--- a/udata/migrations/2025-05-22-purge-duplicate-activities.py
+++ b/udata/migrations/2025-05-22-purge-duplicate-activities.py
@@ -1,0 +1,87 @@
+"""
+This migration updates Topic.featured to False when it is None.
+"""
+
+import logging
+from datetime import datetime, timedelta
+
+from udata.core.dataset.activities import UserCreatedDataset, UserDeletedDataset, UserUpdatedDataset
+from udata.core.organization.activities import UserUpdatedOrganization
+from udata.core.reuse.activities import UserCreatedReuse, UserDeletedReuse, UserUpdatedReuse
+from udata.core.user.activities import (
+    UserDiscussedDataset,
+    UserDiscussedReuse,
+    UserFollowedDataset,
+    UserFollowedOrganization,
+    UserFollowedReuse,
+)
+
+log = logging.getLogger(__name__)
+
+
+def migrate(db):
+    # Clean duplicate activities in case of discussion or following
+    # - remove the "updated" activity on the discussed/followed object
+    # - remove the activity on the organization
+    # The heuristic is to look for specific activities by the same actor on the targeted object
+    # within a -1 +1 second timespan
+    for action_related_activity, object_updated_activity in [
+        (UserDiscussedDataset, UserUpdatedDataset),
+        (UserDiscussedReuse, UserUpdatedReuse),
+        (UserFollowedDataset, UserUpdatedDataset),
+        (UserFollowedReuse, UserUpdatedReuse),
+    ]:
+        org_activity_count = 0
+        object_activity_count = 0
+        activities = (
+            action_related_activity.objects()
+            .order_by("-created_at")
+            .no_dereference()  # We use no_dereference in query to prevent DBref DoesNotExist errors
+            .no_cache()
+        )
+        log.info(
+            f"{datetime.utcnow()}: Processing {activities.count()} {action_related_activity} activities..."
+        )
+        for act in activities:
+            object_activity_count += object_updated_activity.objects(
+                actor=act.actor.id,
+                related_to=act.related_to.id,
+                created_at__gte=act.created_at - timedelta(seconds=1),
+                created_at__lte=act.created_at + timedelta(seconds=1),
+            ).count()
+            org_activity_count += UserUpdatedOrganization.objects(
+                actor=act.actor.id,
+                created_at__gte=act.created_at - timedelta(seconds=1),
+                created_at__lte=act.created_at + timedelta(seconds=1),
+            ).count()
+        log.info(
+            f"{datetime.utcnow()}: Deleted {object_activity_count} {object_updated_activity} and {org_activity_count} UserUpdatedOrganization activities"
+        )
+
+    # Clean duplicated UserUpdatedOrganization activities on organization for any object related activity
+    for object_related_activity in [
+        UserCreatedDataset,
+        UserUpdatedDataset,
+        UserDeletedDataset,
+        UserCreatedReuse,
+        UserUpdatedReuse,
+        UserDeletedReuse,
+        UserFollowedOrganization,
+    ]:
+        count = 0
+        activities = (
+            object_related_activity.objects()
+            .order_by("-created_at")
+            .no_dereference()  # We use no_dereference in query to prevent DBref DoesNotExist errors
+            .no_cache()
+        )
+        log.info(
+            f"{datetime.utcnow()}: Processing {activities.count()} {object_related_activity} activities..."
+        )
+        for act in activities:
+            count += UserUpdatedOrganization.objects(
+                actor=act.actor.id,
+                created_at__gte=act.created_at - timedelta(seconds=1),
+                created_at__lte=act.created_at + timedelta(seconds=1),
+            ).count()
+        log.info(f"{datetime.utcnow()}: Deleted {count} UserUpdatedOrganization activities")

--- a/udata/mongo/datetime_fields.py
+++ b/udata/mongo/datetime_fields.py
@@ -67,6 +67,7 @@ class Datetimed(object):
         ),
         sortable=True,
         readonly=True,
+        auditable=False,
     )
 
 


### PR DESCRIPTION
Branch is based on https://github.com/opendatateam/udata/pull/3308.

We're cleaning activities based on known activities duplicates pattern.
Example, when a user followed a dataset, three activities were created:
- UserFollowedDataset
- UserUpdatedDataset
- UserUpdatedOrganization

We keep the first specific activity and clean other duplicates, based on a query of expected duplicated activities by this actor in a close timespan.